### PR TITLE
RFC/PROPOSAL: add user_id to event.schema

### DIFF
--- a/schema/1.0.0/event.schema.json
+++ b/schema/1.0.0/event.schema.json
@@ -46,7 +46,7 @@
       ]
     },
     "client_id": {
-      "description": "The client issuing the query.  This could be a unique browser, a microservice that performs searches, a crawling bot. If only authenticated users are tracked, then you could use a specific user id here, otherwise you should use something permanent and track user id as an _Additional Property_.",
+      "description": "The client issuing the query.  This could be a unique browser, a microservice that performs searches, a crawling bot.",
       "type": "string",
       "maxLength": 100,
       "examples": ["5e3b2a1c-8b7d-4f2e-a3d4-c9b2e1f3a4b5","quepid-nightly-bot", "BugsBunny::Firefox@0967084"]

--- a/schema/1.0.0/event.schema.json
+++ b/schema/1.0.0/event.schema.json
@@ -51,6 +51,12 @@
       "maxLength": 100,
       "examples": ["5e3b2a1c-8b7d-4f2e-a3d4-c9b2e1f3a4b5","quepid-nightly-bot", "BugsBunny::Firefox@0967084"]
     },    
+    "user_id": {
+      "description": "The user ID associated with the person performing the interactions being logged on the site. Can be null/empty in case of an unauthenticated user.",
+      "type": "string",
+      "maxLength": 100,
+      "examples": ["5e3b2a1c-8b7d-4f2e-a3d4-c9b2e1f3a4b5"]
+    },
     "timestamp": {
       "description": "When the event took place.",
       "type": "string",


### PR DESCRIPTION

## What/Why
### What are you proposing?
We propose that the event schema contain a dedicated user ID field so that consumers of UBI data can disambiguate between `client_id` and `user_id` and better standardize what we recommend the integrators track. 

### What users have asked for this feature?
We have spoken to data analysts who work on analyzing user behavior and they mentioned that the terms `client_id`, `session_id` and `user_id` have distinct meanings that cannot be merged.

### What problems are you trying to solve?
The `client_id` in analytics parlance usually refers to a hash of the browser and its version. This would mean that if multiple unauthenticated users were using the same browser version, their activity would fall under the same id. The current approach has another caveat: if a user ID is logged in the `client_id` field, then the behaviors of unauthenticated users won't be logged. With this proposal, there won't be such a confusion any more. In case of an unauthenticated user, the user_id can remain empty.

#### Are there any security considerations?
No additional security impact as the existing recommendation was to already track the user ID under the `client_id` field

#### Are there any breaking changes to the API
No

### What is the user experience going to be?
Customer can configure and analyze the user-behaviors along an additional axis that is well-separated from `client_id`.

#### Are there breaking changes to the User Experience?
No

### Why should it be built? Any reason not to?
This will allow the separate customer personas (front-end developer and behavior analyst) to be able to perform their tasks better with less coordination required as it reduces ambiguity around what attributes are tracked in which fields.

### What will it take to execute?
1. Merging this pull request
2. Documentation and samples updates.

### Any remaining open questions?
No.