### PR TITLE
RFC/PROPOSAL: add session_id to event.schema

### DIFF
--- a/schema/1.0.0/event.schema.json
+++ b/schema/1.0.0/event.schema.json
@@ -4,7 +4,7 @@
   "title": "Event tracking for UBI",
   "description": "Version 1.0.0; last updated 2024-06-14.  An event that occurred, typically in response to a user.",
   "type": "object",
-  "required": ["action_name", "query_id", "timestamp"],
+  "required": ["action_name", "query_id", "session_id", "timestamp"],
   "properties": {
     "application": {
       "description": "name of the application tracking UBI events.",
@@ -44,6 +44,12 @@
           "examples": ["1234-user-5678"]
         }
       ]
+    },
+    "session_id": {
+      "description": "The session of the user creating the interactions. This allows us to correlate the interactions with the other events created by a service that recognizes session IDs. Can be used to track unique visits for authenticated and anonymous users.",
+      "type": "string",
+      "maxLength": 100,
+      "examples": ["84266fdbd31d4c2c6d0665f7e8380fa3"]
     },
     "client_id": {
       "description": "The client issuing the query.  This could be a unique browser, a microservice that performs searches, a crawling bot. If only authenticated users are tracked, then you could use a specific user id here, otherwise you should use something permanent and track user id as an _Additional Property_.",


### PR DESCRIPTION
## What/Why
### What are you proposing?
We propose that the event schema contain a dedicated session ID field so that consumers of UBI data can track what users (authenticated and anonymous) are doing on dedicated visits. `client_id` does not uniquely identify a user (since two users with the same browser version would point to the same `client_id`) and the `user_id` proposed in [this PR](https://github.com/o19s/ubi/pull/15) will not always be available.

### What users have asked for this feature?
We have spoken to data analysts who work on analyzing user behavior.

### What problems are you trying to solve?
The analysts we spoke to mentioned that a `session_id` is an important field in _addition_ to `client_id` and `user_id` to understand shifts in the user behavior over time. They also mentioned how they often need to correlate search-interactions tied to a session against the other interactions that would also be tied to a session.

#### Are there any security considerations?
No additional security impact as the existing recommendation was to already track the user ID under the `client_id` field. This is of a similar impact.

#### Are there any breaking changes to the API
Yes, the `session_id` is proposed as a required field.

### What is the user experience going to be?
Customer can configure and analyze the user-behaviors along an additional axis that is well-separated from `client_id` and `user_id`.

#### Are there breaking changes to the User Experience?
No

### Why should it be built? Any reason not to?
This will allow the separate customer personas (front-end developer and behavior analyst) to be able to perform their tasks better with less coordination required as it reduces ambiguity around what attributes are tracked in which fields.

### What will it take to execute?
1. Merging this pull request
2. Documentation and samples updates.

### Any remaining open questions?
No.