### PR TITLE
RFC/PROPOSAL: add object_id_type to event.schema

### DIFF
--- a/schema/1.0.0/event.schema.json
+++ b/schema/1.0.0/event.schema.json
@@ -94,6 +94,20 @@
                 }
               ]            
             },
+            "object_id_type": {
+              "description": "The type of the object id that the user is searching for. For a social e-commerce site, these could include product, user, post, comment and so on.",
+              "oneOf": [
+                {
+                  "type": "string",
+                  "maxLength": 100,
+                  "enum": ["product", "user", "post", "comment", "video"]
+                },
+                {
+                  "type": "string",
+                  "maxLength": 100
+                }
+              ]
+            },
             "object_id_field":{
               "description": "The name of the field that has the id of the objects that will be stored in the backend queries data store. So it you have a query for products and want to save the SKUs, then this might be `sku` and if you are querying for people, maybe this is `ssn`.  If you do not provide this value then the default primary identifier in your search index will be used.  For example `_id` on OpenSearch. ",
               "type": "string",


### PR DESCRIPTION
## What/Why
### What are you proposing?
We propose that the `object` field in the event schema contain a an `object_id_type` so that consumers of UBI data can know what the `object_id` refers to. The `object_id` itself should not be counted on having that information and the `object_id_field` only discusses what field in a DB index would contain that value.

### What users have asked for this feature?
We have spoken to data analysts who work on analyzing user behavior.

### What problems are you trying to solve?
We are trying to solve the problem of helping the analysts parse out interactions related to products/videos/posts/users on the same app. With only an `object_id`, we are requiring the front-end developer to know how to package that `object_id` so that an analyst can analyze the same data.

#### Are there any security considerations?
No additional security impact.

#### Are there any breaking changes to the API
No

### What is the user experience going to be?
Customer can configure the `object_id_type` to denote what the type of searched item is.

#### Are there breaking changes to the User Experience?
No

### Why should it be built? Any reason not to?
This will allow for the analyst to more easily understand things like user pattern to product purchase, build personalization on products and click-through-rate for ads.

### What will it take to execute?
1. Merging this pull request
2. Documentation and samples updates.

### Any remaining open questions?
No.