### PR TITLE
fix[event.schema.json]: remove click_through

### DIFF
--- a/schema/1.0.0/event.schema.json
+++ b/schema/1.0.0/event.schema.json
@@ -22,7 +22,7 @@
         {
           "type": "string",
           "maxLength": 100,
-          "enum": ["click_through", "add_to_cart", "click", "watch", "view", "purchase"]
+          "enum": ["add_to_cart", "click", "watch", "view", "purchase"]
         },
         {
           "type": "string",


### PR DESCRIPTION
This is a minor change. I think we should remove the `enum` value `click_through` as that indicates a subset of `click` and has specific connotations in advertising.