### PR TITLE
fix[event.schema.json]: query_id optional

### DIFF
--- a/schema/1.0.0/event.schema.json
+++ b/schema/1.0.0/event.schema.json
@@ -4,7 +4,7 @@
   "title": "Event tracking for UBI",
   "description": "Version 1.0.0; last updated 2024-06-14.  An event that occurred, typically in response to a user.",
   "type": "object",
-  "required": ["action_name", "query_id", "timestamp"],
+  "required": ["action_name", "timestamp"],
   "properties": {
     "application": {
       "description": "name of the application tracking UBI events.",


### PR DESCRIPTION
This is again a small, backwards-compatible change so I am not writing up the full RFC for this. The `query_id` field is required in the current schema. However, the scope of UBI is broader than only tracking the behavior of users after a search is performed. Indeed, the demo tracks user data before searches and writes an empty query ID to the index. This PR fixes that antipattern of a user writing an empty value to a required field.

Fixes [this issue](https://github.com/o19s/ubi/issues/14)