### PR TITLE
Adds impression to action enum

### DIFF
--- a/schema/1.0.0/event.schema.json
+++ b/schema/1.0.0/event.schema.json
@@ -22,7 +22,7 @@
         {
           "type": "string",
           "maxLength": 100,
-          "enum": ["click_through", "add_to_cart", "click", "watch", "view", "purchase"]
+          "enum": ["click_through", "add_to_cart", "click", "watch", "view", "purchase", "impression"]
         },
         {
           "type": "string",


### PR DESCRIPTION
This PR adds impression as an event type.

The intent of this action (to differentiate from view) is to record an event when an impression of an object is in view (for a given criteria).

In some contexts impression and view may be synonymous (e.g., ad impression / view) however in other contexts this is likely to be different (e.g., an impression of a product tile vs a view of the product page, an impression of a video program).