### PR TITLE
UBI Specification 1.3.0 Branch

### DIFF
--- a/docs/html/1.3.0/event.schema.html
+++ b/docs/html/1.3.0/event.schema.html
@@ -1,0 +1,1649 @@
+
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Overpass:300,400,600,800">
+    <script src="https://code.jquery.com/jquery-3.4.1.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
+	<link rel="stylesheet" type="text/css" href="schema_doc.css">
+    <script src="https://use.fontawesome.com/facf9fa52c.js"></script>
+    <script src="schema_doc.min.js"></script>
+    <meta charset="utf-8"/>
+        
+    
+    <title>Event tracking for UBI</title>
+</head>
+<body onload="anchorOnLoad();" id="root"><div class="text-right">
+            <button class="btn btn-primary" type="button" data-toggle="collapse" data-target=".collapse:not(.show)" aria-expanded="false">Expand all</button>
+            <button class="btn btn-primary" type="button" data-toggle="collapse" data-target=".collapse.show" aria-expanded="false">Collapse all</button>
+        </div>
+
+    <div class="breadcrumbs"></div> <h1>Event tracking for UBI</h1><span class="badge badge-dark value-type">Type: object</span><br/>
+<span class="description"><p>Version 1.3.0; last updated 2025-02-26.  An event that occurred, typically in response to a user.</p>
+</span>
+        
+
+        
+        
+
+        
+<div class="accordion" id="accordionapplication">
+    <div class="card">
+        <div class="card-header" id="headingapplication">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#application"
+                        aria-expanded="" aria-controls="application" onclick="setAnchor('#application')"><span class="property-name">application</span></button>
+            </h2>
+        </div>
+
+        <div id="application"
+             class="collapse property-definition-div" aria-labelledby="headingapplication"
+             data-parent="#accordionapplication">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#application" onclick="anchorLink('application')">application</a></div><span class="badge badge-dark value-type">Type: string</span><br/>
+<span class="description"><p>Name of the application that is integrated with UBI.  You can think of application as in a source of search queries.  For example, if you have a type ahead and a traditional search UI, then you might have <code>type-ahead</code> and <code>primary-search</code> as values.</p>
+</span>
+        
+
+        
+        <p><span class="badge badge-light restriction max-length-restriction" id="application_maxLength">Must be at most <code>100</code> characters long</span></p>
+
+        <br/>
+<div class="badge badge-secondary">Examples:</div>
+<br/><div id="application_ex1" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="s2">&quot;type-ahead&quot;</span>
+</pre></div>
+</div><div id="application_ex2" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="s2">&quot;primary-search&quot;</span>
+</pre></div>
+</div><div id="application_ex3" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="s2">&quot;amazon-shop&quot;</span>
+</pre></div>
+</div><div id="application_ex4" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="s2">&quot;ABC-microservice&quot;</span>
+</pre></div>
+</div><div id="application_ex5" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="s2">&quot;doctor-search&quot;</span>
+</pre></div>
+</div>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="accordion" id="accordionaction_name">
+    <div class="card">
+        <div class="card-header" id="headingaction_name">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#action_name"
+                        aria-expanded="" aria-controls="action_name" onclick="setAnchor('#action_name')"><span class="property-name">action_name</span> <span class="badge badge-warning required-property">Required</span></button>
+            </h2>
+        </div>
+
+        <div id="action_name"
+             class="collapse property-definition-div" aria-labelledby="headingaction_name"
+             data-parent="#accordionaction_name">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#action_name" onclick="anchorLink('action_name')">action_name</a></div><br/>
+<span class="description"><p>The name of the action that triggered the event.  We have a set of common defaults, however you can pass in whatever you want.</p>
+</span><div class="one-of-value" id="action_name_oneOf"><h2 class="handle">
+  <label>One of</label>
+</h2><ul class="nav nav-tabs" id="tabsaction_name_oneOf_oneOf" role="tablist"><li class="nav-item">
+            <a class="nav-link active oneOf-option"
+               id="action_name_oneOf_i0" data-toggle="tab" href="#tab-pane_action_name_oneOf_i0" role="tab"
+               onclick="setAnchor('#action_name_oneOf_i0')"
+            >Option 1</a>
+        </li><li class="nav-item">
+            <a class="nav-link oneOf-option"
+               id="action_name_oneOf_i1" data-toggle="tab" href="#tab-pane_action_name_oneOf_i1" role="tab"
+               onclick="setAnchor('#action_name_oneOf_i1')"
+            >Option 2</a>
+        </li></ul>
+<div class="tab-content card"><div class="tab-pane fade card-body active show"
+             id="tab-pane_action_name_oneOf_i0" role="tabpanel">
+            
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#action_name" onclick="anchorLink('action_name')">action_name</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#action_name_oneOf" onclick="anchorLink('action_name_oneOf')">oneOf</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#action_name_oneOf_i0" onclick="anchorLink('action_name_oneOf_i0')">item 0</a></div><span class="badge badge-dark value-type">Type: enum (of string)</span><br/>
+<div class="enum-value" id="action_name_oneOf_i0_enum">
+            <h4>Must be one of:</h4>
+            <ul class="list-group"><li class="list-group-item enum-item">"add_to_cart"</li><li class="list-group-item enum-item">"click"</li><li class="list-group-item enum-item">"watch"</li><li class="list-group-item enum-item">"view"</li><li class="list-group-item enum-item">"purchase"</li><li class="list-group-item enum-item">"impression"</li></ul>
+            </div>
+        
+
+        
+        
+
+        
+        </div><div class="tab-pane fade card-body "
+             id="tab-pane_action_name_oneOf_i1" role="tabpanel">
+            
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#action_name" onclick="anchorLink('action_name')">action_name</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#action_name_oneOf" onclick="anchorLink('action_name_oneOf')">oneOf</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#action_name_oneOf_i1" onclick="anchorLink('action_name_oneOf_i1')">item 1</a></div><span class="badge badge-dark value-type">Type: string</span><br/>
+
+        
+
+        
+        <p><span class="badge badge-light restriction max-length-restriction" id="action_name_oneOf_i1_maxLength">Must be at most <code>100</code> characters long</span></p>
+
+        
+        </div></div></div>
+        
+
+        
+        
+
+        
+            </div>
+        </div>
+    </div>
+</div>
+<div class="accordion" id="accordionquery_id">
+    <div class="card">
+        <div class="card-header" id="headingquery_id">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#query_id"
+                        aria-expanded="" aria-controls="query_id" onclick="setAnchor('#query_id')"><span class="property-name">query_id</span></button>
+            </h2>
+        </div>
+
+        <div id="query_id"
+             class="collapse property-definition-div" aria-labelledby="headingquery_id"
+             data-parent="#accordionquery_id">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#query_id" onclick="anchorLink('query_id')">query_id</a></div><span class="badge badge-dark value-type">Type: string</span><br/>
+<span class="description"><p>The unique identifier of a query, typically a UUID, but can be any string.</p>
+</span>
+        
+
+        
+        <p><span class="badge badge-light restriction max-length-restriction" id="query_id_maxLength">Must be at most <code>100</code> characters long</span></p>
+
+        <br/>
+<div class="badge badge-secondary">Examples:</div>
+<br/><div id="query_id_ex1" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="s2">&quot;00112233-4455-6677-8899-aabbccddeeff&quot;</span>
+</pre></div>
+</div><div id="query_id_ex2" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="s2">&quot;1234-user-5678&quot;</span>
+</pre></div>
+</div>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="accordion" id="accordionsession_id">
+    <div class="card">
+        <div class="card-header" id="headingsession_id">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#session_id"
+                        aria-expanded="" aria-controls="session_id" onclick="setAnchor('#session_id')"><span class="property-name">session_id</span></button>
+            </h2>
+        </div>
+
+        <div id="session_id"
+             class="collapse property-definition-div" aria-labelledby="headingsession_id"
+             data-parent="#accordionsession_id">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#session_id" onclick="anchorLink('session_id')">session_id</a></div><span class="badge badge-dark value-type">Type: string</span><br/>
+<span class="description"><p>The session of the user creating the interactions. This allows us to correlate the interactions with the other events created by a service that recognizes session IDs. Can be used to track unique visits for authenticated and anonymous users.</p>
+</span>
+        
+
+        
+        <p><span class="badge badge-light restriction max-length-restriction" id="session_id_maxLength">Must be at most <code>100</code> characters long</span></p>
+
+        <br/>
+<div class="badge badge-secondary">Example:</div>
+<br/><div id="session_id_ex1" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="s2">&quot;84266fdbd31d4c2c6d0665f7e8380fa3&quot;</span>
+</pre></div>
+</div>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="accordion" id="accordionclient_id">
+    <div class="card">
+        <div class="card-header" id="headingclient_id">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#client_id"
+                        aria-expanded="" aria-controls="client_id" onclick="setAnchor('#client_id')"><span class="property-name">client_id</span></button>
+            </h2>
+        </div>
+
+        <div id="client_id"
+             class="collapse property-definition-div" aria-labelledby="headingclient_id"
+             data-parent="#accordionclient_id">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#client_id" onclick="anchorLink('client_id')">client_id</a></div><span class="badge badge-dark value-type">Type: string</span><br/>
+<span class="description"><p>The client issuing the query.  This could be a unique browser, a microservice that performs searches, a crawling bot.</p>
+</span>
+        
+
+        
+        <p><span class="badge badge-light restriction max-length-restriction" id="client_id_maxLength">Must be at most <code>100</code> characters long</span></p>
+
+        <br/>
+<div class="badge badge-secondary">Examples:</div>
+<br/><div id="client_id_ex1" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="s2">&quot;5e3b2a1c-8b7d-4f2e-a3d4-c9b2e1f3a4b5&quot;</span>
+</pre></div>
+</div><div id="client_id_ex2" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="s2">&quot;quepid-nightly-bot&quot;</span>
+</pre></div>
+</div><div id="client_id_ex3" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="s2">&quot;BugsBunny::Firefox@0967084&quot;</span>
+</pre></div>
+</div>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="accordion" id="accordionuser_id">
+    <div class="card">
+        <div class="card-header" id="headinguser_id">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#user_id"
+                        aria-expanded="" aria-controls="user_id" onclick="setAnchor('#user_id')"><span class="property-name">user_id</span></button>
+            </h2>
+        </div>
+
+        <div id="user_id"
+             class="collapse property-definition-div" aria-labelledby="headinguser_id"
+             data-parent="#accordionuser_id">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#user_id" onclick="anchorLink('user_id')">user_id</a></div><span class="badge badge-dark value-type">Type: string</span><br/>
+<span class="description"><p>The user ID associated with the person performing the interactions being logged on the site. Can be null/empty in case of an unauthenticated user.</p>
+</span>
+        
+
+        
+        <p><span class="badge badge-light restriction max-length-restriction" id="user_id_maxLength">Must be at most <code>100</code> characters long</span></p>
+
+        <br/>
+<div class="badge badge-secondary">Example:</div>
+<br/><div id="user_id_ex1" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="s2">&quot;5e3b2a1c-8b7d-4f2e-a3d4-c9b2e1f3a4b5&quot;</span>
+</pre></div>
+</div>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="accordion" id="accordiontimestamp">
+    <div class="card">
+        <div class="card-header" id="headingtimestamp">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#timestamp"
+                        aria-expanded="" aria-controls="timestamp" onclick="setAnchor('#timestamp')"><span class="property-name">timestamp</span> <span class="badge badge-warning required-property">Required</span></button>
+            </h2>
+        </div>
+
+        <div id="timestamp"
+             class="collapse property-definition-div" aria-labelledby="headingtimestamp"
+             data-parent="#accordiontimestamp">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#timestamp" onclick="anchorLink('timestamp')">timestamp</a></div><span class="badge badge-dark value-type">Type: string</span><span class="badge badge-info value-type">Format: date-time</span><br/>
+<span class="description"><p>When the event took place.  This timestamp is formatted according to the ISO 8601 standard. <em>Please note that Opensearch requires a trailing <code>Z</code> or explicit timezone offset.</em></p>
+</span>
+        
+
+        
+        
+
+        <br/>
+<div class="badge badge-secondary">Examples:</div>
+<br/><div id="timestamp_ex1" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="s2">&quot;2018-11-13T20:20:39+00:00&quot;</span>
+</pre></div>
+</div><div id="timestamp_ex2" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="s2">&quot;2018-11-13T20:20:39Z&quot;</span>
+</pre></div>
+</div><div id="timestamp_ex3" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="s2">&quot;2018-11-13T20:20:39&quot;</span>
+</pre></div>
+</div>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="accordion" id="accordionmessage_type">
+    <div class="card">
+        <div class="card-header" id="headingmessage_type">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#message_type"
+                        aria-expanded="" aria-controls="message_type" onclick="setAnchor('#message_type')"><span class="property-name">message_type</span></button>
+            </h2>
+        </div>
+
+        <div id="message_type"
+             class="collapse property-definition-div" aria-labelledby="headingmessage_type"
+             data-parent="#accordionmessage_type">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#message_type" onclick="anchorLink('message_type')">message_type</a></div><span class="badge badge-dark value-type">Type: string</span><br/>
+<span class="description"><p>Group various <code>action_name</code>'s into logical bins.</p>
+</span>
+        
+
+        
+        <p><span class="badge badge-light restriction max-length-restriction" id="message_type_maxLength">Must be at most <code>100</code> characters long</span></p>
+
+        <br/>
+<div class="badge badge-secondary">Examples:</div>
+<br/><div id="message_type_ex1" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="s2">&quot;QUERY&quot;</span>
+</pre></div>
+</div><div id="message_type_ex2" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="s2">&quot;CONVERSION&quot;</span>
+</pre></div>
+</div>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="accordion" id="accordionmessage">
+    <div class="card">
+        <div class="card-header" id="headingmessage">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#message"
+                        aria-expanded="" aria-controls="message" onclick="setAnchor('#message')"><span class="property-name">message</span></button>
+            </h2>
+        </div>
+
+        <div id="message"
+             class="collapse property-definition-div" aria-labelledby="headingmessage"
+             data-parent="#accordionmessage">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#message" onclick="anchorLink('message')">message</a></div><span class="badge badge-dark value-type">Type: string</span><br/>
+<span class="description"><p>Optional text message for the log entry. For example, for a message_type of QUERY, we would expect the text to be about what the user is searching on.</p>
+</span>
+        
+
+        
+        <p><span class="badge badge-light restriction max-length-restriction" id="message_maxLength">Must be at most <code>1024</code> characters long</span></p>
+
+        
+            </div>
+        </div>
+    </div>
+</div>
+<div class="accordion" id="accordionuser_query">
+    <div class="card">
+        <div class="card-header" id="headinguser_query">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#user_query"
+                        aria-expanded="" aria-controls="user_query" onclick="setAnchor('#user_query')"><span class="property-name">user_query</span></button>
+            </h2>
+        </div>
+
+        <div id="user_query"
+             class="collapse property-definition-div" aria-labelledby="headinguser_query"
+             data-parent="#accordionuser_query">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#user_query" onclick="anchorLink('user_query')">user_query</a></div><span class="badge badge-dark value-type">Type: string</span><br/>
+<span class="description"><p>The query as the user entered it.  No length limit specified.</p>
+</span>
+        
+
+        
+        
+
+        
+            </div>
+        </div>
+    </div>
+</div>
+<div class="accordion" id="accordionevent_attributes">
+    <div class="card">
+        <div class="card-header" id="headingevent_attributes">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#event_attributes"
+                        aria-expanded="" aria-controls="event_attributes" onclick="setAnchor('#event_attributes')"><span class="property-name">event_attributes</span></button>
+            </h2>
+        </div>
+
+        <div id="event_attributes"
+             class="collapse property-definition-div" aria-labelledby="headingevent_attributes"
+             data-parent="#accordionevent_attributes">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes" onclick="anchorLink('event_attributes')">event_attributes</a></div><span class="badge badge-dark value-type">Type: object</span><br/>
+<span class="description"><p>Extensible details about a specific event. A common example of an  <em>Additional Properties</em> is the specific identifier of the user (<code>user_id</code>).  Note: a user identifier is different then the required <code>client_id</code> attribute.</p>
+</span>
+        
+
+        
+        
+
+        
+<div class="accordion" id="accordionevent_attributes_object">
+    <div class="card">
+        <div class="card-header" id="headingevent_attributes_object">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#event_attributes_object"
+                        aria-expanded="" aria-controls="event_attributes_object" onclick="setAnchor('#event_attributes_object')"><span class="property-name">object</span></button>
+            </h2>
+        </div>
+
+        <div id="event_attributes_object"
+             class="collapse property-definition-div" aria-labelledby="headingevent_attributes_object"
+             data-parent="#accordionevent_attributes_object">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes" onclick="anchorLink('event_attributes')">event_attributes</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_object" onclick="anchorLink('event_attributes_object')">object</a></div><span class="badge badge-dark value-type">Type: object</span><br/>
+<span class="description"><p>Structure which contains identifying information of the object returned from the query that the user interacts with (i.e.: a book, a product, a post, etc..).</p>
+</span>
+        
+
+        
+        
+
+        
+<div class="accordion" id="accordionevent_attributes_object_object_id">
+    <div class="card">
+        <div class="card-header" id="headingevent_attributes_object_object_id">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#event_attributes_object_object_id"
+                        aria-expanded="" aria-controls="event_attributes_object_object_id" onclick="setAnchor('#event_attributes_object_object_id')"><span class="property-name">object_id</span> <span class="badge badge-warning required-property">Required</span></button>
+            </h2>
+        </div>
+
+        <div id="event_attributes_object_object_id"
+             class="collapse property-definition-div" aria-labelledby="headingevent_attributes_object_object_id"
+             data-parent="#accordionevent_attributes_object_object_id">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes" onclick="anchorLink('event_attributes')">event_attributes</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_object" onclick="anchorLink('event_attributes_object')">object</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_object_object_id" onclick="anchorLink('event_attributes_object_object_id')">object_id</a></div><br/>
+<span class="description"><p>The id that a user could look up and find the object instance within the <em>document corpus</em>.  Examples include: <em>ssn</em>, <em>isbn</em>, <em>ean</em>, etc. Variants need to be incorporated in the <code>object_id</code>, so for a t-shirt that is red, you would need SKU level as the <code>object_id</code>.</p>
+</span><div class="any-of-value" id="event_attributes_object_object_id_anyOf"><h2 class="handle">
+  <label>Any of</label>
+</h2><ul class="nav nav-tabs" id="tabsevent_attributes_object_object_id_anyOf_anyOf" role="tablist"><li class="nav-item">
+            <a class="nav-link active anyOf-option"
+               id="event_attributes_object_object_id_anyOf_i0" data-toggle="tab" href="#tab-pane_event_attributes_object_object_id_anyOf_i0" role="tab"
+               onclick="setAnchor('#event_attributes_object_object_id_anyOf_i0')"
+            >Option 1</a>
+        </li><li class="nav-item">
+            <a class="nav-link anyOf-option"
+               id="event_attributes_object_object_id_anyOf_i1" data-toggle="tab" href="#tab-pane_event_attributes_object_object_id_anyOf_i1" role="tab"
+               onclick="setAnchor('#event_attributes_object_object_id_anyOf_i1')"
+            >Option 2</a>
+        </li></ul>
+<div class="tab-content card"><div class="tab-pane fade card-body active show"
+             id="tab-pane_event_attributes_object_object_id_anyOf_i0" role="tabpanel">
+            
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes" onclick="anchorLink('event_attributes')">event_attributes</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_object" onclick="anchorLink('event_attributes_object')">object</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_object_object_id" onclick="anchorLink('event_attributes_object_object_id')">object_id</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_object_object_id_anyOf" onclick="anchorLink('event_attributes_object_object_id_anyOf')">anyOf</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_object_object_id_anyOf_i0" onclick="anchorLink('event_attributes_object_object_id_anyOf_i0')">item 0</a></div><span class="badge badge-dark value-type">Type: string</span><br/>
+
+        
+
+        
+        <p><span class="badge badge-light restriction max-length-restriction" id="event_attributes_object_object_id_anyOf_i0_maxLength">Must be at most <code>256</code> characters long</span></p>
+
+        
+        </div><div class="tab-pane fade card-body "
+             id="tab-pane_event_attributes_object_object_id_anyOf_i1" role="tabpanel">
+            
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes" onclick="anchorLink('event_attributes')">event_attributes</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_object" onclick="anchorLink('event_attributes_object')">object</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_object_object_id" onclick="anchorLink('event_attributes_object_object_id')">object_id</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_object_object_id_anyOf" onclick="anchorLink('event_attributes_object_object_id_anyOf')">anyOf</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_object_object_id_anyOf_i1" onclick="anchorLink('event_attributes_object_object_id_anyOf_i1')">item 1</a></div><span class="badge badge-dark value-type">Type: integer</span><br/>
+
+        
+
+        
+        
+
+        
+        </div></div></div>
+        
+
+        
+        
+
+        <br/>
+<div class="badge badge-secondary">Examples:</div>
+<br/><div id="event_attributes_object_object_id_ex1" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="s2">&quot;XYZ-12345&quot;</span>
+</pre></div>
+</div><div id="event_attributes_object_object_id_ex2" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="s2">&quot;ISBN 0-061-96436-0&quot;</span>
+</pre></div>
+</div><div id="event_attributes_object_object_id_ex3" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="s2">&quot;123&quot;</span>
+</pre></div>
+</div>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="accordion" id="accordionevent_attributes_object_object_id_type">
+    <div class="card">
+        <div class="card-header" id="headingevent_attributes_object_object_id_type">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#event_attributes_object_object_id_type"
+                        aria-expanded="" aria-controls="event_attributes_object_object_id_type" onclick="setAnchor('#event_attributes_object_object_id_type')"><span class="property-name">object_id_type</span></button>
+            </h2>
+        </div>
+
+        <div id="event_attributes_object_object_id_type"
+             class="collapse property-definition-div" aria-labelledby="headingevent_attributes_object_object_id_type"
+             data-parent="#accordionevent_attributes_object_object_id_type">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes" onclick="anchorLink('event_attributes')">event_attributes</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_object" onclick="anchorLink('event_attributes_object')">object</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_object_object_id_type" onclick="anchorLink('event_attributes_object_object_id_type')">object_id_type</a></div><br/>
+<span class="description"><p>The type of the object id that the user is searching for. For a social e-commerce site, these could include product, user, post, comment and so on.</p>
+</span><div class="one-of-value" id="event_attributes_object_object_id_type_oneOf"><h2 class="handle">
+  <label>One of</label>
+</h2><ul class="nav nav-tabs" id="tabsevent_attributes_object_object_id_type_oneOf_oneOf" role="tablist"><li class="nav-item">
+            <a class="nav-link active oneOf-option"
+               id="event_attributes_object_object_id_type_oneOf_i0" data-toggle="tab" href="#tab-pane_event_attributes_object_object_id_type_oneOf_i0" role="tab"
+               onclick="setAnchor('#event_attributes_object_object_id_type_oneOf_i0')"
+            >Option 1</a>
+        </li><li class="nav-item">
+            <a class="nav-link oneOf-option"
+               id="event_attributes_object_object_id_type_oneOf_i1" data-toggle="tab" href="#tab-pane_event_attributes_object_object_id_type_oneOf_i1" role="tab"
+               onclick="setAnchor('#event_attributes_object_object_id_type_oneOf_i1')"
+            >Option 2</a>
+        </li></ul>
+<div class="tab-content card"><div class="tab-pane fade card-body active show"
+             id="tab-pane_event_attributes_object_object_id_type_oneOf_i0" role="tabpanel">
+            
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes" onclick="anchorLink('event_attributes')">event_attributes</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_object" onclick="anchorLink('event_attributes_object')">object</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_object_object_id_type" onclick="anchorLink('event_attributes_object_object_id_type')">object_id_type</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_object_object_id_type_oneOf" onclick="anchorLink('event_attributes_object_object_id_type_oneOf')">oneOf</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_object_object_id_type_oneOf_i0" onclick="anchorLink('event_attributes_object_object_id_type_oneOf_i0')">item 0</a></div><span class="badge badge-dark value-type">Type: enum (of string)</span><br/>
+<div class="enum-value" id="event_attributes_object_object_id_type_oneOf_i0_enum">
+            <h4>Must be one of:</h4>
+            <ul class="list-group"><li class="list-group-item enum-item">"product"</li><li class="list-group-item enum-item">"user"</li><li class="list-group-item enum-item">"post"</li><li class="list-group-item enum-item">"comment"</li><li class="list-group-item enum-item">"video"</li></ul>
+            </div>
+        
+
+        
+        
+
+        
+        </div><div class="tab-pane fade card-body "
+             id="tab-pane_event_attributes_object_object_id_type_oneOf_i1" role="tabpanel">
+            
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes" onclick="anchorLink('event_attributes')">event_attributes</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_object" onclick="anchorLink('event_attributes_object')">object</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_object_object_id_type" onclick="anchorLink('event_attributes_object_object_id_type')">object_id_type</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_object_object_id_type_oneOf" onclick="anchorLink('event_attributes_object_object_id_type_oneOf')">oneOf</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_object_object_id_type_oneOf_i1" onclick="anchorLink('event_attributes_object_object_id_type_oneOf_i1')">item 1</a></div><span class="badge badge-dark value-type">Type: string</span><br/>
+
+        
+
+        
+        <p><span class="badge badge-light restriction max-length-restriction" id="event_attributes_object_object_id_type_oneOf_i1_maxLength">Must be at most <code>100</code> characters long</span></p>
+
+        
+        </div></div></div>
+        
+
+        
+        
+
+        
+            </div>
+        </div>
+    </div>
+</div>
+<div class="accordion" id="accordionevent_attributes_object_object_id_field">
+    <div class="card">
+        <div class="card-header" id="headingevent_attributes_object_object_id_field">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#event_attributes_object_object_id_field"
+                        aria-expanded="" aria-controls="event_attributes_object_object_id_field" onclick="setAnchor('#event_attributes_object_object_id_field')"><span class="property-name">object_id_field</span></button>
+            </h2>
+        </div>
+
+        <div id="event_attributes_object_object_id_field"
+             class="collapse property-definition-div" aria-labelledby="headingevent_attributes_object_object_id_field"
+             data-parent="#accordionevent_attributes_object_object_id_field">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes" onclick="anchorLink('event_attributes')">event_attributes</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_object" onclick="anchorLink('event_attributes_object')">object</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_object_object_id_field" onclick="anchorLink('event_attributes_object_object_id_field')">object_id_field</a></div><span class="badge badge-dark value-type">Type: string</span><br/>
+<span class="description"><p>The name of the field that has the id of the objects that will be stored in the backend queries data store. So it you have a query for products and want to save the SKUs, then this might be <code>sku</code> and if you are querying for people, maybe this is <code>ssn</code>.  If you do not provide this value then the default primary identifier in your search index will be used.  For example <code>_id</code> on OpenSearch. </p>
+</span>
+        
+
+        
+        <p><span class="badge badge-light restriction max-length-restriction" id="event_attributes_object_object_id_field_maxLength">Must be at most <code>100</code> characters long</span></p>
+
+        
+            </div>
+        </div>
+    </div>
+</div>
+<div class="accordion" id="accordionevent_attributes_object_internal_id">
+    <div class="card">
+        <div class="card-header" id="headingevent_attributes_object_internal_id">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#event_attributes_object_internal_id"
+                        aria-expanded="" aria-controls="event_attributes_object_internal_id" onclick="setAnchor('#event_attributes_object_internal_id')"><span class="property-name">internal_id</span></button>
+            </h2>
+        </div>
+
+        <div id="event_attributes_object_internal_id"
+             class="collapse property-definition-div" aria-labelledby="headingevent_attributes_object_internal_id"
+             data-parent="#accordionevent_attributes_object_internal_id">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes" onclick="anchorLink('event_attributes')">event_attributes</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_object" onclick="anchorLink('event_attributes_object')">object</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_object_internal_id" onclick="anchorLink('event_attributes_object_internal_id')">internal_id</a></div><br/>
+<span class="description"><p>A unique id that the an individual search engine uses internally to index the object via.  For example, in OpenSearch, think the <code>_id</code> field in the indices.</p>
+</span><div class="any-of-value" id="event_attributes_object_internal_id_anyOf"><h2 class="handle">
+  <label>Any of</label>
+</h2><ul class="nav nav-tabs" id="tabsevent_attributes_object_internal_id_anyOf_anyOf" role="tablist"><li class="nav-item">
+            <a class="nav-link active anyOf-option"
+               id="event_attributes_object_internal_id_anyOf_i0" data-toggle="tab" href="#tab-pane_event_attributes_object_internal_id_anyOf_i0" role="tab"
+               onclick="setAnchor('#event_attributes_object_internal_id_anyOf_i0')"
+            >Option 1</a>
+        </li><li class="nav-item">
+            <a class="nav-link anyOf-option"
+               id="event_attributes_object_internal_id_anyOf_i1" data-toggle="tab" href="#tab-pane_event_attributes_object_internal_id_anyOf_i1" role="tab"
+               onclick="setAnchor('#event_attributes_object_internal_id_anyOf_i1')"
+            >Option 2</a>
+        </li></ul>
+<div class="tab-content card"><div class="tab-pane fade card-body active show"
+             id="tab-pane_event_attributes_object_internal_id_anyOf_i0" role="tabpanel">
+            
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes" onclick="anchorLink('event_attributes')">event_attributes</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_object" onclick="anchorLink('event_attributes_object')">object</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_object_internal_id" onclick="anchorLink('event_attributes_object_internal_id')">internal_id</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_object_internal_id_anyOf" onclick="anchorLink('event_attributes_object_internal_id_anyOf')">anyOf</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_object_internal_id_anyOf_i0" onclick="anchorLink('event_attributes_object_internal_id_anyOf_i0')">item 0</a></div><span class="badge badge-dark value-type">Type: string</span><br/>
+
+        
+
+        
+        <p><span class="badge badge-light restriction max-length-restriction" id="event_attributes_object_internal_id_anyOf_i0_maxLength">Must be at most <code>256</code> characters long</span></p>
+
+        
+        </div><div class="tab-pane fade card-body "
+             id="tab-pane_event_attributes_object_internal_id_anyOf_i1" role="tabpanel">
+            
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes" onclick="anchorLink('event_attributes')">event_attributes</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_object" onclick="anchorLink('event_attributes_object')">object</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_object_internal_id" onclick="anchorLink('event_attributes_object_internal_id')">internal_id</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_object_internal_id_anyOf" onclick="anchorLink('event_attributes_object_internal_id_anyOf')">anyOf</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_object_internal_id_anyOf_i1" onclick="anchorLink('event_attributes_object_internal_id_anyOf_i1')">item 1</a></div><span class="badge badge-dark value-type">Type: integer</span><br/>
+
+        
+
+        
+        
+
+        
+        </div></div></div>
+        
+
+        
+        
+
+        <br/>
+<div class="badge badge-secondary">Examples:</div>
+<br/><div id="event_attributes_object_internal_id_ex1" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="s2">&quot;1&quot;</span>
+</pre></div>
+</div><div id="event_attributes_object_internal_id_ex2" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="s2">&quot;123456&quot;</span>
+</pre></div>
+</div>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="accordion" id="accordionevent_attributes_object_additionalProperties">
+    <div class="card">
+        <div class="card-header" id="headingevent_attributes_object_additionalProperties">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#event_attributes_object_additionalProperties"
+                        aria-expanded="" aria-controls="event_attributes_object_additionalProperties" onclick="setAnchor('#event_attributes_object_additionalProperties')"><em><span class="property-name">Additional Properties</span></em></button>
+            </h2>
+        </div>
+
+        <div id="event_attributes_object_additionalProperties"
+             class="collapse property-definition-div" aria-labelledby="headingevent_attributes_object_additionalProperties"
+             data-parent="#accordionevent_attributes_object_additionalProperties">
+            <div class="card-body pl-5"><p class="additional-properties">Additional Properties of any type are allowed.</p>
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes" onclick="anchorLink('event_attributes')">event_attributes</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_object" onclick="anchorLink('event_attributes_object')">object</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_object_additionalProperties" onclick="anchorLink('event_attributes_object_additionalProperties')">additionalProperties</a></div><span class="badge badge-dark value-type">Type: object</span><br/>
+
+        
+
+        
+        
+
+        
+            </div>
+        </div>
+    </div>
+</div>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="accordion" id="accordionevent_attributes_position">
+    <div class="card">
+        <div class="card-header" id="headingevent_attributes_position">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#event_attributes_position"
+                        aria-expanded="" aria-controls="event_attributes_position" onclick="setAnchor('#event_attributes_position')"><span class="property-name">position</span> <span class="badge badge-warning required-property">Required</span></button>
+            </h2>
+        </div>
+
+        <div id="event_attributes_position"
+             class="collapse property-definition-div" aria-labelledby="headingevent_attributes_position"
+             data-parent="#accordionevent_attributes_position">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes" onclick="anchorLink('event_attributes')">event_attributes</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_position" onclick="anchorLink('event_attributes_position')">position</a></div><br/>
+<span class="description"><p>Structure that contains information on the location of the event origin, such as screen x,y coordinates, or the nth object out of 10 results.</p>
+</span><div class="one-of-value" id="event_attributes_position_oneOf"><h2 class="handle">
+  <label>One of</label>
+</h2><ul class="nav nav-tabs" id="tabsevent_attributes_position_oneOf_oneOf" role="tablist"><li class="nav-item">
+            <a class="nav-link active oneOf-option"
+               id="event_attributes_position_oneOf_i0" data-toggle="tab" href="#tab-pane_event_attributes_position_oneOf_i0" role="tab"
+               onclick="setAnchor('#event_attributes_position_oneOf_i0')"
+            >Option 1</a>
+        </li><li class="nav-item">
+            <a class="nav-link oneOf-option"
+               id="event_attributes_position_oneOf_i1" data-toggle="tab" href="#tab-pane_event_attributes_position_oneOf_i1" role="tab"
+               onclick="setAnchor('#event_attributes_position_oneOf_i1')"
+            >Option 2</a>
+        </li></ul>
+<div class="tab-content card"><div class="tab-pane fade card-body active show"
+             id="tab-pane_event_attributes_position_oneOf_i0" role="tabpanel">
+            
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes" onclick="anchorLink('event_attributes')">event_attributes</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_position" onclick="anchorLink('event_attributes_position')">position</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_position_oneOf" onclick="anchorLink('event_attributes_position_oneOf')">oneOf</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_position_oneOf_i0" onclick="anchorLink('event_attributes_position_oneOf_i0')">item 0</a></div><span class="badge badge-dark value-type">Type: object</span><br/>
+
+        
+
+        
+        
+
+        
+<div class="accordion" id="accordionevent_attributes_position_oneOf_i0_ordinal">
+    <div class="card">
+        <div class="card-header" id="headingevent_attributes_position_oneOf_i0_ordinal">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#event_attributes_position_oneOf_i0_ordinal"
+                        aria-expanded="" aria-controls="event_attributes_position_oneOf_i0_ordinal" onclick="setAnchor('#event_attributes_position_oneOf_i0_ordinal')"><span class="property-name">ordinal</span> <span class="badge badge-warning required-property">Required</span></button>
+            </h2>
+        </div>
+
+        <div id="event_attributes_position_oneOf_i0_ordinal"
+             class="collapse property-definition-div" aria-labelledby="headingevent_attributes_position_oneOf_i0_ordinal"
+             data-parent="#accordionevent_attributes_position_oneOf_i0_ordinal">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes" onclick="anchorLink('event_attributes')">event_attributes</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_position" onclick="anchorLink('event_attributes_position')">position</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_position_oneOf" onclick="anchorLink('event_attributes_position_oneOf')">oneOf</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_position_oneOf_i0" onclick="anchorLink('event_attributes_position_oneOf_i0')">item 0</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_position_oneOf_i0_ordinal" onclick="anchorLink('event_attributes_position_oneOf_i0_ordinal')">ordinal</a></div><span class="badge badge-dark value-type">Type: integer</span><br/>
+<span class="description"><p>The nth position of the document on the search results page. For grid layout this would be left to right, ignoring wrapping.</p>
+</span>
+        
+
+        
+        
+
+        <br/>
+<div class="badge badge-secondary">Examples:</div>
+<br/><div id="event_attributes_position_oneOf_i0_ordinal_ex1" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="mf">1</span>
+</pre></div>
+</div><div id="event_attributes_position_oneOf_i0_ordinal_ex2" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="mf">3</span>
+</pre></div>
+</div><div id="event_attributes_position_oneOf_i0_ordinal_ex3" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="mf">24</span>
+</pre></div>
+</div>
+            </div>
+        </div>
+    </div>
+</div>
+        </div><div class="tab-pane fade card-body "
+             id="tab-pane_event_attributes_position_oneOf_i1" role="tabpanel">
+            
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes" onclick="anchorLink('event_attributes')">event_attributes</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_position" onclick="anchorLink('event_attributes_position')">position</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_position_oneOf" onclick="anchorLink('event_attributes_position_oneOf')">oneOf</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_position_oneOf_i1" onclick="anchorLink('event_attributes_position_oneOf_i1')">item 1</a></div><span class="badge badge-dark value-type">Type: object</span><br/>
+
+        
+
+        
+        
+
+        
+<div class="accordion" id="accordionevent_attributes_position_oneOf_i1_xy">
+    <div class="card">
+        <div class="card-header" id="headingevent_attributes_position_oneOf_i1_xy">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#event_attributes_position_oneOf_i1_xy"
+                        aria-expanded="" aria-controls="event_attributes_position_oneOf_i1_xy" onclick="setAnchor('#event_attributes_position_oneOf_i1_xy')"><span class="property-name">xy</span> <span class="badge badge-warning required-property">Required</span></button>
+            </h2>
+        </div>
+
+        <div id="event_attributes_position_oneOf_i1_xy"
+             class="collapse property-definition-div" aria-labelledby="headingevent_attributes_position_oneOf_i1_xy"
+             data-parent="#accordionevent_attributes_position_oneOf_i1_xy">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes" onclick="anchorLink('event_attributes')">event_attributes</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_position" onclick="anchorLink('event_attributes_position')">position</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_position_oneOf" onclick="anchorLink('event_attributes_position_oneOf')">oneOf</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_position_oneOf_i1" onclick="anchorLink('event_attributes_position_oneOf_i1')">item 1</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_position_oneOf_i1_xy" onclick="anchorLink('event_attributes_position_oneOf_i1_xy')">xy</a></div><span class="badge badge-dark value-type">Type: object</span><br/>
+<span class="description"><p>The x,y coordinates on the screen for triggering an event.</p>
+</span>
+        
+
+        
+        
+
+        
+<div class="accordion" id="accordionevent_attributes_position_oneOf_i1_xy_x">
+    <div class="card">
+        <div class="card-header" id="headingevent_attributes_position_oneOf_i1_xy_x">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#event_attributes_position_oneOf_i1_xy_x"
+                        aria-expanded="" aria-controls="event_attributes_position_oneOf_i1_xy_x" onclick="setAnchor('#event_attributes_position_oneOf_i1_xy_x')"><span class="property-name">x</span> <span class="badge badge-warning required-property">Required</span></button>
+            </h2>
+        </div>
+
+        <div id="event_attributes_position_oneOf_i1_xy_x"
+             class="collapse property-definition-div" aria-labelledby="headingevent_attributes_position_oneOf_i1_xy_x"
+             data-parent="#accordionevent_attributes_position_oneOf_i1_xy_x">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes" onclick="anchorLink('event_attributes')">event_attributes</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_position" onclick="anchorLink('event_attributes_position')">position</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_position_oneOf" onclick="anchorLink('event_attributes_position_oneOf')">oneOf</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_position_oneOf_i1" onclick="anchorLink('event_attributes_position_oneOf_i1')">item 1</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_position_oneOf_i1_xy" onclick="anchorLink('event_attributes_position_oneOf_i1_xy')">xy</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_position_oneOf_i1_xy_x" onclick="anchorLink('event_attributes_position_oneOf_i1_xy_x')">x</a></div><span class="badge badge-dark value-type">Type: number</span><br/>
+<span class="description"><p>The horizontal location on the page or screen of the event.</p>
+</span>
+        
+
+        
+        
+
+        
+            </div>
+        </div>
+    </div>
+</div>
+<div class="accordion" id="accordionevent_attributes_position_oneOf_i1_xy_y">
+    <div class="card">
+        <div class="card-header" id="headingevent_attributes_position_oneOf_i1_xy_y">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#event_attributes_position_oneOf_i1_xy_y"
+                        aria-expanded="" aria-controls="event_attributes_position_oneOf_i1_xy_y" onclick="setAnchor('#event_attributes_position_oneOf_i1_xy_y')"><span class="property-name">y</span> <span class="badge badge-warning required-property">Required</span></button>
+            </h2>
+        </div>
+
+        <div id="event_attributes_position_oneOf_i1_xy_y"
+             class="collapse property-definition-div" aria-labelledby="headingevent_attributes_position_oneOf_i1_xy_y"
+             data-parent="#accordionevent_attributes_position_oneOf_i1_xy_y">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes" onclick="anchorLink('event_attributes')">event_attributes</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_position" onclick="anchorLink('event_attributes_position')">position</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_position_oneOf" onclick="anchorLink('event_attributes_position_oneOf')">oneOf</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_position_oneOf_i1" onclick="anchorLink('event_attributes_position_oneOf_i1')">item 1</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_position_oneOf_i1_xy" onclick="anchorLink('event_attributes_position_oneOf_i1_xy')">xy</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_position_oneOf_i1_xy_y" onclick="anchorLink('event_attributes_position_oneOf_i1_xy_y')">y</a></div><span class="badge badge-dark value-type">Type: number</span><br/>
+<span class="description"><p>The vertical location on the page or screen of the event.</p>
+</span>
+        
+
+        
+        
+
+        
+            </div>
+        </div>
+    </div>
+</div>
+            </div>
+        </div>
+    </div>
+</div>
+        </div></div></div>
+        
+
+        
+        
+
+        
+<div class="accordion" id="accordionevent_attributes_position_additionalProperties">
+    <div class="card">
+        <div class="card-header" id="headingevent_attributes_position_additionalProperties">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#event_attributes_position_additionalProperties"
+                        aria-expanded="" aria-controls="event_attributes_position_additionalProperties" onclick="setAnchor('#event_attributes_position_additionalProperties')"><em><span class="property-name">Additional Properties</span></em></button>
+            </h2>
+        </div>
+
+        <div id="event_attributes_position_additionalProperties"
+             class="collapse property-definition-div" aria-labelledby="headingevent_attributes_position_additionalProperties"
+             data-parent="#accordionevent_attributes_position_additionalProperties">
+            <div class="card-body pl-5"><p class="additional-properties">Additional Properties of any type are allowed.</p>
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes" onclick="anchorLink('event_attributes')">event_attributes</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_position" onclick="anchorLink('event_attributes_position')">position</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_position_additionalProperties" onclick="anchorLink('event_attributes_position_additionalProperties')">additionalProperties</a></div><span class="badge badge-dark value-type">Type: object</span><br/>
+
+        
+
+        
+        
+
+        
+            </div>
+        </div>
+    </div>
+</div>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="accordion" id="accordionevent_attributes_additionalProperties">
+    <div class="card">
+        <div class="card-header" id="headingevent_attributes_additionalProperties">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#event_attributes_additionalProperties"
+                        aria-expanded="" aria-controls="event_attributes_additionalProperties" onclick="setAnchor('#event_attributes_additionalProperties')"><em><span class="property-name">Additional Properties</span></em></button>
+            </h2>
+        </div>
+
+        <div id="event_attributes_additionalProperties"
+             class="collapse property-definition-div" aria-labelledby="headingevent_attributes_additionalProperties"
+             data-parent="#accordionevent_attributes_additionalProperties">
+            <div class="card-body pl-5"><p class="additional-properties">Additional Properties of any type are allowed.</p>
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes" onclick="anchorLink('event_attributes')">event_attributes</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#event_attributes_additionalProperties" onclick="anchorLink('event_attributes_additionalProperties')">additionalProperties</a></div><span class="badge badge-dark value-type">Type: object</span><br/>
+
+        
+
+        
+        
+
+        
+            </div>
+        </div>
+    </div>
+</div>
+            </div>
+        </div>
+    </div>
+</div>
+
+    <footer>
+        <p class="generated-by-footer">Generated using <a href="https://github.com/coveooss/json-schema-for-humans">json-schema-for-humans</a> on 2025-02-26 at 16:31:18 +0100</p>
+    </footer></body>
+</html>

--- a/docs/html/1.3.0/query.request.schema.html
+++ b/docs/html/1.3.0/query.request.schema.html
@@ -1,0 +1,485 @@
+
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Overpass:300,400,600,800">
+    <script src="https://code.jquery.com/jquery-3.4.1.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
+	<link rel="stylesheet" type="text/css" href="schema_doc.css">
+    <script src="https://use.fontawesome.com/facf9fa52c.js"></script>
+    <script src="schema_doc.min.js"></script>
+    <meta charset="utf-8"/>
+        
+    
+    <title>Query Tracking for UBI</title>
+</head>
+<body onload="anchorOnLoad();" id="root"><div class="text-right">
+            <button class="btn btn-primary" type="button" data-toggle="collapse" data-target=".collapse:not(.show)" aria-expanded="false">Expand all</button>
+            <button class="btn btn-primary" type="button" data-toggle="collapse" data-target=".collapse.show" aria-expanded="false">Collapse all</button>
+        </div>
+
+    <div class="breadcrumbs"></div> <h1>Query Tracking for UBI</h1><span class="badge badge-dark value-type">Type: object</span><br/>
+<span class="description"><p>Version 1.3.0; last updated 2025-02-26.  A query made by a user should include these attributes for UBI tracking.</p>
+</span>
+        
+
+        
+        
+
+        
+<div class="accordion" id="accordionapplication">
+    <div class="card">
+        <div class="card-header" id="headingapplication">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#application"
+                        aria-expanded="" aria-controls="application" onclick="setAnchor('#application')"><span class="property-name">application</span></button>
+            </h2>
+        </div>
+
+        <div id="application"
+             class="collapse property-definition-div" aria-labelledby="headingapplication"
+             data-parent="#accordionapplication">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#application" onclick="anchorLink('application')">application</a></div><span class="badge badge-dark value-type">Type: string</span><br/>
+<span class="description"><p>Name of the application that is integrated with UBI.  You can think of application as in a source of search queries.  For example, if you have a type ahead and a traditional search UI, then you might have <code>type-ahead</code> and <code>primary-search</code> as values.</p>
+</span>
+        
+
+        
+        <p><span class="badge badge-light restriction max-length-restriction" id="application_maxLength">Must be at most <code>100</code> characters long</span></p>
+
+        <br/>
+<div class="badge badge-secondary">Examples:</div>
+<br/><div id="application_ex1" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="s2">&quot;type-ahead&quot;</span>
+</pre></div>
+</div><div id="application_ex2" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="s2">&quot;primary-search&quot;</span>
+</pre></div>
+</div><div id="application_ex3" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="s2">&quot;amazon-shop&quot;</span>
+</pre></div>
+</div><div id="application_ex4" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="s2">&quot;ABC-microservice&quot;</span>
+</pre></div>
+</div><div id="application_ex5" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="s2">&quot;doctor-search&quot;</span>
+</pre></div>
+</div>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="accordion" id="accordionquery_id">
+    <div class="card">
+        <div class="card-header" id="headingquery_id">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#query_id"
+                        aria-expanded="" aria-controls="query_id" onclick="setAnchor('#query_id')"><span class="property-name">query_id</span></button>
+            </h2>
+        </div>
+
+        <div id="query_id"
+             class="collapse property-definition-div" aria-labelledby="headingquery_id"
+             data-parent="#accordionquery_id">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#query_id" onclick="anchorLink('query_id')">query_id</a></div><span class="badge badge-dark value-type">Type: string</span><br/>
+<span class="description"><p>The unique identifier of a query, typically a UUID, but can be any string.</p>
+</span>
+        
+
+        
+        <p><span class="badge badge-light restriction max-length-restriction" id="query_id_maxLength">Must be at most <code>100</code> characters long</span></p>
+
+        <br/>
+<div class="badge badge-secondary">Examples:</div>
+<br/><div id="query_id_ex1" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="s2">&quot;00112233-4455-6677-8899-aabbccddeeff&quot;</span>
+</pre></div>
+</div><div id="query_id_ex2" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="s2">&quot;1234-user-5678&quot;</span>
+</pre></div>
+</div>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="accordion" id="accordionclient_id">
+    <div class="card">
+        <div class="card-header" id="headingclient_id">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#client_id"
+                        aria-expanded="" aria-controls="client_id" onclick="setAnchor('#client_id')"><span class="property-name">client_id</span></button>
+            </h2>
+        </div>
+
+        <div id="client_id"
+             class="collapse property-definition-div" aria-labelledby="headingclient_id"
+             data-parent="#accordionclient_id">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#client_id" onclick="anchorLink('client_id')">client_id</a></div><span class="badge badge-dark value-type">Type: string</span><br/>
+<span class="description"><p>The client issuing the query.  This could be a unique browser, a microservice that performs searches, a crawling bot. If only authenticated users are tracked, then you could use a specific user id here, otherwise you should use something permanent and track user id as an <em>Additional Property</em>.</p>
+</span>
+        
+
+        
+        <p><span class="badge badge-light restriction max-length-restriction" id="client_id_maxLength">Must be at most <code>100</code> characters long</span></p>
+
+        <br/>
+<div class="badge badge-secondary">Examples:</div>
+<br/><div id="client_id_ex1" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="s2">&quot;5e3b2a1c-8b7d-4f2e-a3d4-c9b2e1f3a4b5&quot;</span>
+</pre></div>
+</div><div id="client_id_ex2" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="s2">&quot;quepid-nightly-bot&quot;</span>
+</pre></div>
+</div><div id="client_id_ex3" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="s2">&quot;BugsBunny::Firefox@0967084&quot;</span>
+</pre></div>
+</div>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="accordion" id="accordionuser_query">
+    <div class="card">
+        <div class="card-header" id="headinguser_query">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#user_query"
+                        aria-expanded="" aria-controls="user_query" onclick="setAnchor('#user_query')"><span class="property-name">user_query</span> <span class="badge badge-warning required-property">Required</span></button>
+            </h2>
+        </div>
+
+        <div id="user_query"
+             class="collapse property-definition-div" aria-labelledby="headinguser_query"
+             data-parent="#accordionuser_query">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#user_query" onclick="anchorLink('user_query')">user_query</a></div><span class="badge badge-dark value-type">Type: string</span><br/>
+<span class="description"><p>The query as the user entered it.  No length limit specified.</p>
+</span>
+        
+
+        
+        
+
+        
+            </div>
+        </div>
+    </div>
+</div>
+<div class="accordion" id="accordionquery_attributes">
+    <div class="card">
+        <div class="card-header" id="headingquery_attributes">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#query_attributes"
+                        aria-expanded="" aria-controls="query_attributes" onclick="setAnchor('#query_attributes')"><span class="property-name">query_attributes</span></button>
+            </h2>
+        </div>
+
+        <div id="query_attributes"
+             class="collapse property-definition-div" aria-labelledby="headingquery_attributes"
+             data-parent="#accordionquery_attributes">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#query_attributes" onclick="anchorLink('query_attributes')">query_attributes</a></div><span class="badge badge-dark value-type">Type: object</span><br/>
+<span class="description"><p>Any query modifiers like filter choices or pagination. Other attributes such as experiment identifiers that need to be tracked with the query.</p>
+</span>
+        
+
+        
+        
+
+        
+<div class="accordion" id="accordionquery_attributes_additionalProperties">
+    <div class="card">
+        <div class="card-header" id="headingquery_attributes_additionalProperties">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#query_attributes_additionalProperties"
+                        aria-expanded="" aria-controls="query_attributes_additionalProperties" onclick="setAnchor('#query_attributes_additionalProperties')"><em><span class="property-name">Additional Properties</span></em></button>
+            </h2>
+        </div>
+
+        <div id="query_attributes_additionalProperties"
+             class="collapse property-definition-div" aria-labelledby="headingquery_attributes_additionalProperties"
+             data-parent="#accordionquery_attributes_additionalProperties">
+            <div class="card-body pl-5"><p class="additional-properties">Additional Properties of any type are allowed.</p>
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#query_attributes" onclick="anchorLink('query_attributes')">query_attributes</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#query_attributes_additionalProperties" onclick="anchorLink('query_attributes_additionalProperties')">additionalProperties</a></div><span class="badge badge-dark value-type">Type: object</span><br/>
+
+        
+
+        
+        
+
+        
+            </div>
+        </div>
+    </div>
+</div>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="accordion" id="accordionobject_id_field">
+    <div class="card">
+        <div class="card-header" id="headingobject_id_field">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#object_id_field"
+                        aria-expanded="" aria-controls="object_id_field" onclick="setAnchor('#object_id_field')"><span class="property-name">object_id_field</span></button>
+            </h2>
+        </div>
+
+        <div id="object_id_field"
+             class="collapse property-definition-div" aria-labelledby="headingobject_id_field"
+             data-parent="#accordionobject_id_field">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#object_id_field" onclick="anchorLink('object_id_field')">object_id_field</a></div><span class="badge badge-dark value-type">Type: string</span><br/>
+<span class="description"><p>The name of the field that has the id of the objects that will be stored in the backend queries data store. So it you have a query for products and want to save the SKUs, then this might be <code>sku</code> and if you are querying for people, maybe this is <code>ssn</code>.  If you do not provide this value then the default primary identifier in your search index will be used.  For example <code>_id</code> on OpenSearch. </p>
+</span>
+        
+
+        
+        <p><span class="badge badge-light restriction max-length-restriction" id="object_id_field_maxLength">Must be at most <code>100</code> characters long</span></p>
+
+        
+            </div>
+        </div>
+    </div>
+</div>
+<div class="accordion" id="accordiontimestamp">
+    <div class="card">
+        <div class="card-header" id="headingtimestamp">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#timestamp"
+                        aria-expanded="" aria-controls="timestamp" onclick="setAnchor('#timestamp')"><span class="property-name">timestamp</span></button>
+            </h2>
+        </div>
+
+        <div id="timestamp"
+             class="collapse property-definition-div" aria-labelledby="headingtimestamp"
+             data-parent="#accordiontimestamp">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#timestamp" onclick="anchorLink('timestamp')">timestamp</a></div><span class="badge badge-dark value-type">Type: string</span><span class="badge badge-info value-type">Format: date-time</span><br/>
+<span class="description"><p>When the query was issued.  This timestamp is formatted according to the ISO 8601 standard.  In many implementations of the UBI Query plugin the timestamp will be set for you at the time of the query being run.  If you are replaying data, or want to track the timezone of the caller specifically, instead of using the search engine's timezone, then you will need to provide the timestamp instead. <em>Please note that Opensearch requires a trailing <code>Z</code> or explicit timezone offset.</em></p>
+</span>
+        
+
+        
+        
+
+        <br/>
+<div class="badge badge-secondary">Examples:</div>
+<br/><div id="timestamp_ex1" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="s2">&quot;2018-11-13T20:20:39+00:00&quot;</span>
+</pre></div>
+</div><div id="timestamp_ex2" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="s2">&quot;2018-11-13T20:20:39Z&quot;</span>
+</pre></div>
+</div><div id="timestamp_ex3" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="s2">&quot;2018-11-13T20:20:39&quot;</span>
+</pre></div>
+</div>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="accordion" id="accordionquery_response_id">
+    <div class="card">
+        <div class="card-header" id="headingquery_response_id">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#query_response_id"
+                        aria-expanded="" aria-controls="query_response_id" onclick="setAnchor('#query_response_id')"><span class="property-name">query_response_id</span></button>
+            </h2>
+        </div>
+
+        <div id="query_response_id"
+             class="collapse property-definition-div" aria-labelledby="headingquery_response_id"
+             data-parent="#accordionquery_response_id">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#query_response_id" onclick="anchorLink('query_response_id')">query_response_id</a></div><span class="badge badge-dark value-type">Type: string</span><br/>
+<span class="description"><p>The id of the search engine response.</p>
+</span>
+        
+
+        
+        
+
+        <br/>
+<div class="badge badge-secondary">Examples:</div>
+<br/><div id="query_response_id_ex1" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="s2">&quot;5e3b2a1c-8b7d-4f2e-a3d4-c9b2e1f3a4b5&quot;</span>
+</pre></div>
+</div><div id="query_response_id_ex2" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="s2">&quot;00112233-4455-6677-8899-aabbccddeeff&quot;</span>
+</pre></div>
+</div>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="accordion" id="accordionquery_response_hit_ids">
+    <div class="card">
+        <div class="card-header" id="headingquery_response_hit_ids">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#query_response_hit_ids"
+                        aria-expanded="" aria-controls="query_response_hit_ids" onclick="setAnchor('#query_response_hit_ids')"><span class="property-name">query_response_hit_ids</span></button>
+            </h2>
+        </div>
+
+        <div id="query_response_hit_ids"
+             class="collapse property-definition-div" aria-labelledby="headingquery_response_hit_ids"
+             data-parent="#accordionquery_response_hit_ids">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#query_response_hit_ids" onclick="anchorLink('query_response_hit_ids')">query_response_hit_ids</a></div><span class="badge badge-dark value-type">Type: array of string</span><br/>
+<span class="description"><p>The ids of the documents that were returned by the search engine for this query in the order they were returned.</p>
+</span>
+        
+
+        
+        
+
+         <span class="badge badge-info no-additional">No Additional Items</span><h4>Each item of this array must be:</h4>
+    <div class="card">
+        <div class="card-body items-definition" id="query_response_hit_ids_items">
+            
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#query_response_hit_ids" onclick="anchorLink('query_response_hit_ids')">query_response_hit_ids</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#query_response_hit_ids_items" onclick="anchorLink('query_response_hit_ids_items')">query_response_hit_ids items</a></div><span class="badge badge-dark value-type">Type: string</span><br/>
+
+        
+
+        
+        
+
+        
+        </div>
+    </div><br/>
+<div class="badge badge-secondary">Examples:</div>
+<br/><button class="btn btn-light example-show collapsed" data-toggle="collapse" data-target="#query_response_hit_ids_ex1" aria-controls="query_response_hit_ids_ex1"></button><div id="query_response_hit_ids_ex1" class="collapse jumbotron examples"><div class="highlight"><pre><span></span><span class="p">[</span>
+<span class="w">    </span><span class="s2">&quot;B07XLFYN6S&quot;</span><span class="p">,</span>
+<span class="w">    </span><span class="s2">&quot;B013UFPODY&quot;</span><span class="p">,</span>
+<span class="w">    </span><span class="s2">&quot;B07SHS91DQ&quot;</span><span class="p">,</span>
+<span class="w">    </span><span class="s2">&quot;B077FVRM4P&quot;</span><span class="p">,</span>
+<span class="w">    </span><span class="s2">&quot;B07ZCRSVBB&quot;</span><span class="p">,</span>
+<span class="w">    </span><span class="s2">&quot;B07H7RWGRY&quot;</span><span class="p">,</span>
+<span class="w">    </span><span class="s2">&quot;B085XP9ZY5&quot;</span><span class="p">,</span>
+<span class="w">    </span><span class="s2">&quot;B01LW2UNZQ&quot;</span><span class="p">,</span>
+<span class="w">    </span><span class="s2">&quot;B01MQVMFUN&quot;</span><span class="p">,</span>
+<span class="w">    </span><span class="s2">&quot;B08KFPPJ3Y&quot;</span><span class="p">,</span>
+<span class="w">    </span><span class="s2">&quot;B08THXDPVM&quot;</span><span class="p">,</span>
+<span class="w">    </span><span class="s2">&quot;B07V2GZSMS&quot;</span><span class="p">,</span>
+<span class="w">    </span><span class="s2">&quot;B0828XP9RM&quot;</span><span class="p">,</span>
+<span class="w">    </span><span class="s2">&quot;B07G96L41J&quot;</span><span class="p">,</span>
+<span class="w">    </span><span class="s2">&quot;B07V224V9X&quot;</span><span class="p">,</span>
+<span class="w">    </span><span class="s2">&quot;B095LHL2G5&quot;</span><span class="p">,</span>
+<span class="w">    </span><span class="s2">&quot;B083W38C8H&quot;</span><span class="p">,</span>
+<span class="w">    </span><span class="s2">&quot;B06XWPHG53&quot;</span><span class="p">,</span>
+<span class="w">    </span><span class="s2">&quot;B07J4WHNFC&quot;</span><span class="p">,</span>
+<span class="w">    </span><span class="s2">&quot;B071HMM81V&quot;</span>
+<span class="p">]</span>
+</pre></div>
+</div><div id="query_response_hit_ids_ex2" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="p">[</span>
+<span class="w">    </span><span class="s2">&quot;1&quot;</span><span class="p">,</span>
+<span class="w">    </span><span class="s2">&quot;2&quot;</span><span class="p">,</span>
+<span class="w">    </span><span class="s2">&quot;3&quot;</span><span class="p">,</span>
+<span class="w">    </span><span class="s2">&quot;4&quot;</span><span class="p">,</span>
+<span class="w">    </span><span class="s2">&quot;5&quot;</span>
+<span class="p">]</span>
+</pre></div>
+</div><div id="query_response_hit_ids_ex3" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="p">[]</span>
+</pre></div>
+</div>
+            </div>
+        </div>
+    </div>
+</div>
+
+    <footer>
+        <p class="generated-by-footer">Generated using <a href="https://github.com/coveooss/json-schema-for-humans">json-schema-for-humans</a> on 2025-02-26 at 16:31:18 +0100</p>
+    </footer></body>
+</html>

--- a/docs/html/1.3.0/query.response.schema.html
+++ b/docs/html/1.3.0/query.response.schema.html
@@ -1,0 +1,76 @@
+
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Overpass:300,400,600,800">
+    <script src="https://code.jquery.com/jquery-3.4.1.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
+	<link rel="stylesheet" type="text/css" href="schema_doc.css">
+    <script src="https://use.fontawesome.com/facf9fa52c.js"></script>
+    <script src="schema_doc.min.js"></script>
+    <meta charset="utf-8"/>
+        
+    
+    <title>Query Response When Using UBI</title>
+</head>
+<body onload="anchorOnLoad();" id="root"><div class="text-right">
+            <button class="btn btn-primary" type="button" data-toggle="collapse" data-target=".collapse:not(.show)" aria-expanded="false">Expand all</button>
+            <button class="btn btn-primary" type="button" data-toggle="collapse" data-target=".collapse.show" aria-expanded="false">Collapse all</button>
+        </div>
+
+    <div class="breadcrumbs"></div> <h1>Query Response When Using UBI</h1><span class="badge badge-dark value-type">Type: object</span><br/>
+<span class="description"><p>Version 1.3.0; last updated 2025-02-26.  The response to a query made by a user should support this schema.</p>
+</span>
+        
+
+        
+        
+
+        
+<div class="accordion" id="accordionquery_id">
+    <div class="card">
+        <div class="card-header" id="headingquery_id">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#query_id"
+                        aria-expanded="" aria-controls="query_id" onclick="setAnchor('#query_id')"><span class="property-name">query_id</span> <span class="badge badge-warning required-property">Required</span></button>
+            </h2>
+        </div>
+
+        <div id="query_id"
+             class="collapse property-definition-div" aria-labelledby="headingquery_id"
+             data-parent="#accordionquery_id">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#query_id" onclick="anchorLink('query_id')">query_id</a></div><span class="badge badge-dark value-type">Type: string</span><br/>
+<span class="description"><p>The unique identifier of a query, typically a UUID, but can be any string.</p>
+</span>
+        
+
+        
+        <p><span class="badge badge-light restriction max-length-restriction" id="query_id_maxLength">Must be at most <code>100</code> characters long</span></p>
+
+        <br/>
+<div class="badge badge-secondary">Examples:</div>
+<br/><div id="query_id_ex1" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="s2">&quot;00112233-4455-6677-8899-aabbccddeeff&quot;</span>
+</pre></div>
+</div><div id="query_id_ex2" class="jumbotron examples"><div class="highlight"><pre><span></span><span class="s2">&quot;1234-user-5678&quot;</span>
+</pre></div>
+</div>
+            </div>
+        </div>
+    </div>
+</div>
+
+    <footer>
+        <p class="generated-by-footer">Generated using <a href="https://github.com/coveooss/json-schema-for-humans">json-schema-for-humans</a> on 2025-02-26 at 16:31:18 +0100</p>
+    </footer></body>
+</html>

--- a/docs/html/1.3.0/schema_doc.css
+++ b/docs/html/1.3.0/schema_doc.css
@@ -1,0 +1,181 @@
+body {
+  font: 16px/1.5em "Overpass", "Open Sans", Helvetica, sans-serif;
+  color: #333;
+  font-weight: 300;
+  padding: 40px;
+}
+
+.btn.btn-link {
+    font-size: 18px;
+    user-select: text;
+}
+
+.jsfh-animated-property {
+    animation: eclair;
+    animation-iteration-count: 1;
+    animation-fill-mode: forwards;
+    animation-duration: .75s;
+
+}
+
+@keyframes eclair {
+    0%,100% {
+        transform: scale(1);
+    }
+    50% {
+        transform: scale(1.03);
+    }
+}
+
+.btn.btn-primary {
+    margin: 10px;
+}
+
+.btn.example-show.collapsed:before {
+    content: "show"
+}
+
+.btn.example-show:before {
+    content: "hide"
+}
+
+.description.collapse:not(.show) {
+    max-height: 100px !important;
+    overflow: hidden;
+
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+}
+
+.description.collapsing {
+    min-height: 100px !important;
+}
+
+.collapse-description-link.collapsed:after  {
+    content: '+ Read More';
+}
+
+.collapse-description-link:not(.collapsed):after {
+    content: '- Read Less';
+}
+
+.badge {
+    font-size: 100%;
+	margin-bottom: 0.5rem;
+    margin-top: 0.5rem;
+}
+
+.badge.value-type {
+    font-size: 120%;
+    margin-right: 5px;
+    margin-bottom: 10px;
+}
+
+
+.badge.default-value {
+    font-size: 120%;
+    margin-left: 5px;
+    margin-bottom: 10px;
+}
+
+.badge.restriction {
+    display: inline-block;
+}
+
+.badge.required-property,.badge.deprecated-property,.badge.pattern-property,.badge.no-additional {
+    font-size: 100%;
+    margin-left: 10px;
+}
+
+.accordion div.card:only-child {
+    border-bottom: 1px solid rgba(0, 0, 0, 0.125);
+}
+
+.examples {
+	padding: 1rem !important;
+}
+
+.examples pre {
+    margin-bottom: 0;
+}
+
+.highlight.jumbotron {
+    padding: 1rem !important;
+}
+
+.generated-by-footer {
+    margin-top: 1em;
+    text-align: right;
+}
+
+/* From https://github.com/richleland/pygments-css/blob/master/friendly.css, see https://github.com/trentm/python-markdown2/wiki/fenced-code-blocks */
+.highlight  { background: #e9ecef; } /* Changed from #f0f0f0 in the original style to be the same as bootstrap's jumbotron */
+.highlight .hll { background-color: #ffffcc }
+.highlight .c { color: #60a0b0; font-style: italic } /* Comment */
+.highlight .err { border: 1px solid #FF0000 } /* Error */
+.highlight .k { color: #007020; font-weight: bold } /* Keyword */
+.highlight .o { color: #666666 } /* Operator */
+.highlight .ch { color: #60a0b0; font-style: italic } /* Comment.Hashbang */
+.highlight .cm { color: #60a0b0; font-style: italic } /* Comment.Multiline */
+.highlight .cp { color: #007020 } /* Comment.Preproc */
+.highlight .cpf { color: #60a0b0; font-style: italic } /* Comment.PreprocFile */
+.highlight .c1 { color: #60a0b0; font-style: italic } /* Comment.Single */
+.highlight .cs { color: #60a0b0; background-color: #fff0f0 } /* Comment.Special */
+.highlight .gd { color: #A00000 } /* Generic.Deleted */
+.highlight .ge { font-style: italic } /* Generic.Emph */
+.highlight .gr { color: #FF0000 } /* Generic.Error */
+.highlight .gh { color: #000080; font-weight: bold } /* Generic.Heading */
+.highlight .gi { color: #00A000 } /* Generic.Inserted */
+.highlight .go { color: #888888 } /* Generic.Output */
+.highlight .gp { color: #c65d09; font-weight: bold } /* Generic.Prompt */
+.highlight .gs { font-weight: bold } /* Generic.Strong */
+.highlight .gu { color: #800080; font-weight: bold } /* Generic.Subheading */
+.highlight .gt { color: #0044DD } /* Generic.Traceback */
+.highlight .kc { color: #007020; font-weight: bold } /* Keyword.Constant */
+.highlight .kd { color: #007020; font-weight: bold } /* Keyword.Declaration */
+.highlight .kn { color: #007020; font-weight: bold } /* Keyword.Namespace */
+.highlight .kp { color: #007020 } /* Keyword.Pseudo */
+.highlight .kr { color: #007020; font-weight: bold } /* Keyword.Reserved */
+.highlight .kt { color: #902000 } /* Keyword.Type */
+.highlight .m { color: #40a070 } /* Literal.Number */
+.highlight .s { color: #4070a0 } /* Literal.String */
+.highlight .na { color: #4070a0 } /* Name.Attribute */
+.highlight .nb { color: #007020 } /* Name.Builtin */
+.highlight .nc { color: #0e84b5; font-weight: bold } /* Name.Class */
+.highlight .no { color: #60add5 } /* Name.Constant */
+.highlight .nd { color: #555555; font-weight: bold } /* Name.Decorator */
+.highlight .ni { color: #d55537; font-weight: bold } /* Name.Entity */
+.highlight .ne { color: #007020 } /* Name.Exception */
+.highlight .nf { color: #06287e } /* Name.Function */
+.highlight .nl { color: #002070; font-weight: bold } /* Name.Label */
+.highlight .nn { color: #0e84b5; font-weight: bold } /* Name.Namespace */
+.highlight .nt { color: #062873; font-weight: bold } /* Name.Tag */
+.highlight .nv { color: #bb60d5 } /* Name.Variable */
+.highlight .ow { color: #007020; font-weight: bold } /* Operator.Word */
+.highlight .w { color: #bbbbbb } /* Text.Whitespace */
+.highlight .mb { color: #40a070 } /* Literal.Number.Bin */
+.highlight .mf { color: #40a070 } /* Literal.Number.Float */
+.highlight .mh { color: #40a070 } /* Literal.Number.Hex */
+.highlight .mi { color: #40a070 } /* Literal.Number.Integer */
+.highlight .mo { color: #40a070 } /* Literal.Number.Oct */
+.highlight .sa { color: #4070a0 } /* Literal.String.Affix */
+.highlight .sb { color: #4070a0 } /* Literal.String.Backtick */
+.highlight .sc { color: #4070a0 } /* Literal.String.Char */
+.highlight .dl { color: #4070a0 } /* Literal.String.Delimiter */
+.highlight .sd { color: #4070a0; font-style: italic } /* Literal.String.Doc */
+.highlight .s2 { color: #4070a0 } /* Literal.String.Double */
+.highlight .se { color: #4070a0; font-weight: bold } /* Literal.String.Escape */
+.highlight .sh { color: #4070a0 } /* Literal.String.Heredoc */
+.highlight .si { color: #70a0d0; font-style: italic } /* Literal.String.Interpol */
+.highlight .sx { color: #c65d09 } /* Literal.String.Other */
+.highlight .sr { color: #235388 } /* Literal.String.Regex */
+.highlight .s1 { color: #4070a0 } /* Literal.String.Single */
+.highlight .ss { color: #517918 } /* Literal.String.Symbol */
+.highlight .bp { color: #007020 } /* Name.Builtin.Pseudo */
+.highlight .fm { color: #06287e } /* Name.Function.Magic */
+.highlight .vc { color: #bb60d5 } /* Name.Variable.Class */
+.highlight .vg { color: #bb60d5 } /* Name.Variable.Global */
+.highlight .vi { color: #bb60d5 } /* Name.Variable.Instance */
+.highlight .vm { color: #bb60d5 } /* Name.Variable.Magic */
+.highlight .il { color: #40a070 } /* Literal.Number.Integer.Long */

--- a/schema/1.3.0/event.schema.json
+++ b/schema/1.3.0/event.schema.json
@@ -34,18 +34,9 @@
     },
     "query_id": {
       "description": "The unique identifier of a query, typically a UUID, but can be any string.",
-      "oneOf": [
-        {
-          "type": "string",
-          "format": "uuid",
-          "examples": ["00112233-4455-6677-8899-aabbccddeeff"]
-        },
-        {
-          "type": "string",
-          "maxLength": 100,
-          "examples": ["1234-user-5678"]
-        }
-      ]
+      "type": "string",
+      "maxLength": 100,
+      "examples": ["00112233-4455-6677-8899-aabbccddeeff", "1234-user-5678"]
     },
     "session_id": {
       "description": "The session of the user creating the interactions. This allows us to correlate the interactions with the other events created by a service that recognizes session IDs. Can be used to track unique visits for authenticated and anonymous users.",

--- a/schema/1.3.0/event.schema.json
+++ b/schema/1.3.0/event.schema.json
@@ -151,16 +151,9 @@
                     "type": "object",
                     "properties": {
                       "ordinal": {
-                        "description": "The nth position of the document on the search results page.",
-                        "type": "object",
-                        "properties": {
-                          "index": {
-                            "description": "The position of the document.  For grid layout this would be left to right, ignoring wrapping.",
-                            "type": "integer",
-                            "examples": [1, 3, 24]
-                          }
-                        },
-                        "required": ["index"]
+                        "description": "The nth position of the document on the search results page. For grid layout this would be left to right, ignoring wrapping.",
+                        "type": "integer",
+                        "examples": [1, 3, 24]
                       }
                     },
                     "required": ["ordinal"]

--- a/schema/1.3.0/event.schema.json
+++ b/schema/1.3.0/event.schema.json
@@ -1,0 +1,195 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://o19s.github.io/ubi/schema/1.2.0/event.schema.json",
+  "title": "Event tracking for UBI",
+  "description": "Version 1.2.0; last updated 2024-10-24.  An event that occurred, typically in response to a user.",
+  "type": "object",
+  "required": ["action_name", "timestamp"],
+  "properties": {
+    "application": {
+      "description": "Name of the application that is integrated with UBI.  You can think of application as in a source of search queries.  For example, if you have a type ahead and a traditional search UI, then you might have `type-ahead` and `primary-search` as values.",
+      "type": "string",
+      "maxLength": 100,
+      "examples": [
+          "type-ahead",
+          "primary-search",
+          "amazon-shop",
+          "ABC-microservice",
+          "doctor-search"
+      ]
+    },
+    "action_name": {
+      "description": "The name of the action that triggered the event.  We have a set of common defaults, however you can pass in whatever you want.",
+      "oneOf": [
+        {
+          "type": "string",
+          "maxLength": 100,
+          "enum": ["add_to_cart", "click", "watch", "view", "purchase", "impression"]
+        },
+        {
+          "type": "string",
+          "maxLength": 100
+        }
+      ]
+    },
+    "query_id": {
+      "description": "The unique identifier of a query, typically a UUID, but can be any string.",
+      "oneOf": [
+        {
+          "type": "string",
+          "format": "uuid",
+          "examples": ["00112233-4455-6677-8899-aabbccddeeff"]
+        },
+        {
+          "type": "string",
+          "maxLength": 100,
+          "examples": ["1234-user-5678"]
+        }
+      ]
+    },
+    "session_id": {
+      "description": "The session of the user creating the interactions. This allows us to correlate the interactions with the other events created by a service that recognizes session IDs. Can be used to track unique visits for authenticated and anonymous users.",
+      "type": "string",
+      "maxLength": 100,
+      "examples": ["84266fdbd31d4c2c6d0665f7e8380fa3"]
+    },
+    "client_id": {
+      "description": "The client issuing the query.  This could be a unique browser, a microservice that performs searches, a crawling bot.",
+      "type": "string",
+      "maxLength": 100,
+      "examples": ["5e3b2a1c-8b7d-4f2e-a3d4-c9b2e1f3a4b5","quepid-nightly-bot", "BugsBunny::Firefox@0967084"]
+    },    
+    "user_id": {
+      "description": "The user ID associated with the person performing the interactions being logged on the site. Can be null/empty in case of an unauthenticated user.",
+      "type": "string",
+      "maxLength": 100,
+      "examples": ["5e3b2a1c-8b7d-4f2e-a3d4-c9b2e1f3a4b5"]
+    },
+    "timestamp": {
+      "description": "When the event took place.  This timestamp is formatted according to the ISO 8601 standard. _Please note that Opensearch requires a trailing `Z` or explicit timezone offset._",
+      "type": "string",
+      "format": "date-time",
+      "examples": ["2018-11-13T20:20:39+00:00", "2018-11-13T20:20:39Z", "2018-11-13T20:20:39"]
+    },
+    "message_type": {
+      "description": "Group various `action_name`'s into logical bins.",
+      "type": "string",
+      "maxLength": 100,
+      "examples": ["QUERY", "CONVERSION"],
+      "$comment": "TDB: action_type?  event_type?  Should the front end even define this?"
+    },
+    "message": {
+      "description": "Optional text message for the log entry. For example, for a message_type of QUERY, we would expect the text to be about what the user is searching on.",
+      "type": "string",
+      "maxLength": 1024
+    },
+    "event_attributes": {
+      "description": "Extensible details about a specific event. A common example of an  _Additional Properties_ is the specific identifier of the user (`user_id`).  Note: a user identifier is different then the required `client_id` attribute.",
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["position"],
+      "properties": {
+        "object": {
+          "description": "Structure which contains identifying information of the object returned from the query that the user interacts with (i.e.: a book, a product, a post, etc..).",
+          "type": "object",
+          "additionalProperties": true,
+          "required": ["object_id"],
+          "properties": {
+            "object_id": {
+              "description": "The id that a user could look up and find the object instance within the *document corpus*.  Examples include: _ssn_, _isbn_, _ean_, etc. Variants need to be incorporated in the `object_id`, so for a t-shirt that is red, you would need SKU level as the `object_id`.",
+              "examples": ["XYZ-12345", "ISBN 0-061-96436-0", "123"],
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 256
+                },
+                {
+                  "type": "integer"
+                }
+              ]            
+            },
+            "object_id_type": {
+              "description": "The type of the object id that the user is searching for. For a social e-commerce site, these could include product, user, post, comment and so on.",
+              "oneOf": [
+                {
+                  "type": "string",
+                  "maxLength": 100,
+                  "enum": ["product", "user", "post", "comment", "video"]
+                },
+                {
+                  "type": "string",
+                  "maxLength": 100
+                }
+              ]
+            },
+            "object_id_field":{
+              "description": "The name of the field that has the id of the objects that will be stored in the backend queries data store. So it you have a query for products and want to save the SKUs, then this might be `sku` and if you are querying for people, maybe this is `ssn`.  If you do not provide this value then the default primary identifier in your search index will be used.  For example `_id` on OpenSearch. ",
+              "type": "string",
+              "maxLength": 100
+            },
+            "internal_id": {
+              "description": "A unique id that the an individual search engine uses internally to index the object via.  For example, in OpenSearch, think the `_id` field in the indices.",
+              "examples": ["1", "123456"],
+              "anyOf": [
+                {
+                  "type": "string",
+                  "maxLength": 256
+                },
+                {
+                  "type": "integer"
+                }
+              ]             
+            }            
+          }          
+        },        
+        "position": {
+          "description": "Structure that contains information on the location of the event origin, such as screen x,y coordinates, or the nth object out of 10 results.",
+          "type": "object",
+          "additionalProperties": true,          
+          "oneOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "ordinal": {
+                        "description": "The nth position of the document on the search results page.",
+                        "type": "object",
+                        "properties": {
+                          "index": {
+                            "description": "The position of the document.  For grid layout this would be left to right, ignoring wrapping.",
+                            "type": "integer",
+                            "examples": [1, 3, 24]
+                          }
+                        },
+                        "required": ["index"]
+                      }
+                    },
+                    "required": ["ordinal"]
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "xy": {
+                        "description": "The x,y coordinates on the screen for triggering an event.",
+                        "$comment": "What about bounding boxes?",
+                        "type": "object",
+                        "properties": {
+                          "x": {
+                            "description": "The horizontal location on the page or screen of the event.",
+                            "type": "number"
+                          },
+                          "y": {
+                            "description": "The vertical location on the page or screen of the event.",
+                            "type": "number"
+                          }
+                        },
+                        "required": ["x", "y"]
+                      }
+                    },
+                    "required": ["xy"]
+                  }
+                ]
+        }   
+      }
+    }
+  }
+}

--- a/schema/1.3.0/event.schema.json
+++ b/schema/1.3.0/event.schema.json
@@ -83,6 +83,11 @@
       "type": "string",
       "maxLength": 1024
     },
+    "user_query":{
+      "description": "The query as the user entered it.  No length limit specified.",
+      "type": "string",
+      "$comment": "Currently not required to support recommendation systems etc that might not have a user generated query."
+    },
     "event_attributes": {
       "description": "Extensible details about a specific event. A common example of an  _Additional Properties_ is the specific identifier of the user (`user_id`).  Note: a user identifier is different then the required `client_id` attribute.",
       "type": "object",

--- a/schema/1.3.0/event.schema.json
+++ b/schema/1.3.0/event.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://o19s.github.io/ubi/schema/1.2.0/event.schema.json",
+  "$id": "https://o19s.github.io/ubi/schema/1.3.0/event.schema.json",
   "title": "Event tracking for UBI",
-  "description": "Version 1.2.0; last updated 2024-10-24.  An event that occurred, typically in response to a user.",
+  "description": "Version 1.3.0; last updated 2025-02-26.  An event that occurred, typically in response to a user.",
   "type": "object",
   "required": ["action_name", "timestamp"],
   "properties": {

--- a/schema/1.3.0/query.request.schema.json
+++ b/schema/1.3.0/query.request.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://o19s.github.io/ubi/schema/1.2.0/query.request.schema.json",
+  "title": "Query Tracking for UBI",
+  "description": "Version 1.2.0; last updated 2024-10-24.  A query made by a user should include these attributes for UBI tracking.",
+  "type": "object",
+  "required": [ "user_query" ],
+  "properties": {  
+    "application": {
+      "description": "Name of the application that is integrated with UBI.  You can think of application as in a source of search queries.  For example, if you have a type ahead and a traditional search UI, then you might have `type-ahead` and `primary-search` as values.",
+      "type": "string",
+      "maxLength": 100,
+      "examples": [
+          "type-ahead",
+          "primary-search",
+          "amazon-shop",
+          "ABC-microservice",
+          "doctor-search"
+      ]
+    },    
+    "query_id": {
+      "description": "The unique identifier of a query, typically a UUID, but can be any string.",
+      "oneOf": [
+        {
+          "type": "string",
+          "format": "uuid",
+          "examples": ["00112233-4455-6677-8899-aabbccddeeff"]
+        },
+        {
+          "type": "string",
+          "maxLength": 100,
+          "examples": ["1234-user-5678"]
+        }
+      ]
+    },   
+    "client_id": {
+      "description": "The client issuing the query.  This could be a unique browser, a microservice that performs searches, a crawling bot. If only authenticated users are tracked, then you could use a specific user id here, otherwise you should use something permanent and track user id as an _Additional Property_.",
+      "type": "string",
+      "maxLength": 100,
+      "examples": ["5e3b2a1c-8b7d-4f2e-a3d4-c9b2e1f3a4b5","quepid-nightly-bot", "BugsBunny::Firefox@0967084"]
+    },
+    "user_query":{
+      "description": "The query as the user entered it.  No length limit specified.",
+      "type": "string",
+      "$comment": "Currently not required to support recommendation systems etc that might not have a user generated query."
+    },
+    "query_attributes":{
+      "description": "Any query modifiers like filter choices or pagination. Other attributes such as experiment identifiers that need to be tracked with the query.",
+      "type": "object",
+      "additionalProperties": true
+    },
+    "object_id_field":{
+      "description": "The name of the field that has the id of the objects that will be stored in the backend queries data store. So it you have a query for products and want to save the SKUs, then this might be `sku` and if you are querying for people, maybe this is `ssn`.  If you do not provide this value then the default primary identifier in your search index will be used.  For example `_id` on OpenSearch. ",
+      "type": "string",
+      "maxLength": 100
+    },
+    "timestamp": {
+      "description": "When the query was issued.  This timestamp is formatted according to the ISO 8601 standard.  In many implementations of the UBI Query plugin the timestamp will be set for you at the time of the query being run.  If you are replaying data, or want to track the timezone of the caller specifically, instead of using the search engine's timezone, then you will need to provide the timestamp instead. _Please note that Opensearch requires a trailing `Z` or explicit timezone offset._",
+      "type": "string",
+      "format": "date-time",
+      "examples": ["2018-11-13T20:20:39+00:00", "2018-11-13T20:20:39Z", "2018-11-13T20:20:39"]
+    }
+  }
+}

--- a/schema/1.3.0/query.request.schema.json
+++ b/schema/1.3.0/query.request.schema.json
@@ -20,18 +20,9 @@
     },    
     "query_id": {
       "description": "The unique identifier of a query, typically a UUID, but can be any string.",
-      "oneOf": [
-        {
-          "type": "string",
-          "format": "uuid",
-          "examples": ["00112233-4455-6677-8899-aabbccddeeff"]
-        },
-        {
-          "type": "string",
-          "maxLength": 100,
-          "examples": ["1234-user-5678"]
-        }
-      ]
+      "type": "string",
+      "maxLength": 100,
+      "examples": ["00112233-4455-6677-8899-aabbccddeeff", "1234-user-5678"]
     },   
     "client_id": {
       "description": "The client issuing the query.  This could be a unique browser, a microservice that performs searches, a crawling bot. If only authenticated users are tracked, then you could use a specific user id here, otherwise you should use something permanent and track user id as an _Additional Property_.",

--- a/schema/1.3.0/query.request.schema.json
+++ b/schema/1.3.0/query.request.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://o19s.github.io/ubi/schema/1.2.0/query.request.schema.json",
+  "$id": "https://o19s.github.io/ubi/schema/1.3.0/query.request.schema.json",
   "title": "Query Tracking for UBI",
-  "description": "Version 1.2.0; last updated 2024-10-24.  A query made by a user should include these attributes for UBI tracking.",
+  "description": "Version 1.3.0; last updated 2025-02-26.  A query made by a user should include these attributes for UBI tracking.",
   "type": "object",
   "required": [ "user_query" ],
   "properties": {  
@@ -59,6 +59,19 @@
       "type": "string",
       "format": "date-time",
       "examples": ["2018-11-13T20:20:39+00:00", "2018-11-13T20:20:39Z", "2018-11-13T20:20:39"]
+    },
+    "query_response_id": {
+      "description": "The id of the search engine response.",
+      "type": "string",
+      "examples": ["5e3b2a1c-8b7d-4f2e-a3d4-c9b2e1f3a4b5", "00112233-4455-6677-8899-aabbccddeeff"]
+    },
+    "query_response_hit_ids": {
+      "description": "The ids of the documents that were returned by the search engine for this query in the order they were returned.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "examples": [["B07XLFYN6S", "B013UFPODY", "B07SHS91DQ", "B077FVRM4P", "B07ZCRSVBB", "B07H7RWGRY", "B085XP9ZY5", "B01LW2UNZQ", "B01MQVMFUN", "B08KFPPJ3Y", "B08THXDPVM", "B07V2GZSMS", "B0828XP9RM", "B07G96L41J", "B07V224V9X", "B095LHL2G5", "B083W38C8H", "B06XWPHG53", "B07J4WHNFC", "B071HMM81V"], ["1","2","3","4","5"], []]
     }
   }
 }

--- a/schema/1.3.0/query.response.schema.json
+++ b/schema/1.3.0/query.response.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://o19s.github.io/ubi/schema/1.2.0/query.response.schema.json",
+  "$id": "https://o19s.github.io/ubi/schema/1.3.0/query.response.schema.json",
   "title": "Query Response When Using UBI",
-  "description": "Version 1.2.0; last updated 2024-10-24.  The response to a query made by a user should support this schema.",
+  "description": "Version 1.3.0; last updated 2025-02-26.  The response to a query made by a user should support this schema.",
   "type": "object",
   "required": [ "query_id" ],
   "properties": {  

--- a/schema/1.3.0/query.response.schema.json
+++ b/schema/1.3.0/query.response.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://o19s.github.io/ubi/schema/1.2.0/query.response.schema.json",
+  "title": "Query Response When Using UBI",
+  "description": "Version 1.2.0; last updated 2024-10-24.  The response to a query made by a user should support this schema.",
+  "type": "object",
+  "required": [ "query_id" ],
+  "properties": {  
+    "query_id": {
+      "description": "The unique identifier of a query, typically a UUID, but can be any string.",
+      "oneOf": [
+        {
+          "type": "string",
+          "format": "uuid",
+          "examples": ["00112233-4455-6677-8899-aabbccddeeff"]
+        },
+        {
+          "type": "string",
+          "maxLength": 100,
+          "examples": ["1234-user-5678"]
+        }
+      ]
+    }
+  }
+}

--- a/schema/1.3.0/query.response.schema.json
+++ b/schema/1.3.0/query.response.schema.json
@@ -8,18 +8,9 @@
   "properties": {  
     "query_id": {
       "description": "The unique identifier of a query, typically a UUID, but can be any string.",
-      "oneOf": [
-        {
-          "type": "string",
-          "format": "uuid",
-          "examples": ["00112233-4455-6677-8899-aabbccddeeff"]
-        },
-        {
-          "type": "string",
-          "maxLength": 100,
-          "examples": ["1234-user-5678"]
-        }
-      ]
+      "type": "string",
+      "maxLength": 100,
+      "examples": ["00112233-4455-6677-8899-aabbccddeeff", "1234-user-5678"]
     }
   }
 }


### PR DESCRIPTION
This PR pulls together the changes for UBI specification version 1.3.0.

Issues resolved:
* #35: add `user_query` to events schema
* #33: add `query_response_hit_ids` to query request schema
* https://github.com/opensearch-project/user-behavior-insights/issues/74: removes `index` property from events schema for tracking positional information
* removes `click_through` from enums in events schema

Since working on schemas requires changes in JSON and documentation files it's not trivial to merge all PRs one by one, so this PR replaces several to make the changes for the new version go smoothly:
* closes #37 
* closes #36 
* closes #34 
* #19 by @AnkitSiva 
* closes #23 